### PR TITLE
align to aem 6.4

### DIFF
--- a/integration/src/main/java/de/dev/eth0/elasticsearch/aem/indexing/ElasticSearchIndexContentBuilder.java
+++ b/integration/src/main/java/de/dev/eth0/elasticsearch/aem/indexing/ElasticSearchIndexContentBuilder.java
@@ -47,7 +47,7 @@ import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
-import org.apache.sling.jcr.resource.JcrResourceConstants;
+import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;

--- a/integration/src/main/java/de/dev/eth0/elasticsearch/aem/indexing/ElasticSearchTransportHandler.java
+++ b/integration/src/main/java/de/dev/eth0/elasticsearch/aem/indexing/ElasticSearchTransportHandler.java
@@ -41,6 +41,7 @@ import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.Service;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
+import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
 import org.apache.http.util.EntityUtils;
 import org.apache.sling.commons.json.JSONException;
@@ -155,7 +156,7 @@ public class ElasticSearchTransportHandler implements TransportHandler {
       log.debug(getClass().getSimpleName() + ": Index-Content: " + contentString);
       LOG.debug("Index-Content: " + contentString);
 
-      HttpEntity entity = new NStringEntity(contentString, "UTF-8");
+      HttpEntity entity = new NStringEntity(contentString, ContentType.APPLICATION_JSON);
       Response indexResponse = restClient.performRequest(
               "PUT",
               "/" + content.getIndex() + "/" + content.getType() + "/" + DigestUtils.md5Hex(content.getPath()),

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -42,7 +42,7 @@
         <groupId>com.adobe.aem</groupId>
         <artifactId>uber-jar</artifactId>
         <classifier>obfuscated-apis</classifier>
-        <version>6.1.0</version>
+        <version>6.4.0</version>
         <scope>provided</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
fix new package-name for JcrResourceConstants
update ueber-jar dependency to match aem 6.4